### PR TITLE
Kolejnosc krokow w jenkinsfile, usuniecie jar plugin z pom servera

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,9 @@ pipeline {
     agent any
 
     stages {
-        stage('Verify') {
+        stage('Test') {
             steps {
-                sh 'mvn clean verify'
+                sh 'mvn -B clean test'
             }
         }
 	    stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,14 +4,14 @@ pipeline {
     agent any
 
     stages {
-	    stage('Build') {
+        stage('Verify') {
             steps {
-                sh 'mvn -B -DskipTests clean install'
+                sh 'mvn clean verify'
             }
         }
-    	stage('Test') {
+	    stage('Build') {
             steps {
-                sh 'mvn verify'
+                sh 'mvn -B -DskipTests install'
             }
         }
         stage('Deploy') {
@@ -19,7 +19,7 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh 'scp server/target/server-0.1.war root@51.38.130.222:/opt/tomcat/webapps'
+                sh 'scp server/target/server.war root@51.38.130.222:/opt/tomcat/webapps'
                 sh 'scp client/shade/client.jar root@51.38.130.222:/opt/tomcat/webapps/ROOT'
             }
         }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
        <groupId>academy.konrad.group</groupId>
        <artifactId>battleships</artifactId>
-       <version>${project.version}</version>
+       <version>0.1</version>
     </parent>
     <artifactId>client</artifactId>
     

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -4,13 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    
     <parent>
        <groupId>academy.konrad.group</groupId>
        <artifactId>battleships</artifactId>
-       <version>${project.version}</version> 
+       <version>0.1</version>
     </parent>
     <packaging>war</packaging>
+    <build>
+        <finalName>server</finalName>
+    </build>
     <artifactId>server</artifactId>
     
     <properties>
@@ -30,24 +32,5 @@
             <version>0.1</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.maven.jar}</version>
-                <configuration>
-                    <archive>
-                        <index>true</index>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>${project.groupId}.${project.parent.artifactId}.${project.artifactId}.ServerApp</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>
 


### PR DESCRIPTION
Nasz server nie potrzebuje jar pluginu ponieważ nie wymaga ustawienia mainClass w manifest do działania.